### PR TITLE
add metadata json schema

### DIFF
--- a/config/customfunctions.json
+++ b/config/customfunctions.json
@@ -1,7 +1,9 @@
-﻿{
+{
+  "$schema": "https://developer.microsoft.com/en-us/json-schemas/office-js/custom-functions.schema.json",
   "functions": [
     {
-      "name": "add",
+      "id": "ADD",
+      "name": "ADD",
       "description": "Add two numbers",
       "helpUrl": "http://dev.office.com",
       "result": {
@@ -24,35 +26,13 @@
       ]
     },
     {
-      "name": "addAsync",
-      "description": "Add two numbers (async)",
+      "id": "INCREMENT",
+      "name": "INCREMENT",
+      "description": "Periodically increment a value",
       "helpUrl": "http://dev.office.com",
       "result": {
-        "type": "number",
-        "dimensionality": "scalar"
-      },
-      "parameters": [
-        {
-          "name": "first",
-          "description": "first number to add",
           "type": "number",
           "dimensionality": "scalar"
-        },
-        {
-          "name": "second",
-          "description": "second number to add",
-          "type": "number",
-          "dimensionality": "scalar"
-        }
-      ]
-    },
-    {
-        "name": "INCREMENT",
-        "description": "Periodically increment a value",
-        "helpUrl": "http://dev.office.com",
-        "result": {
-            "type": "number",
-            "dimensionality": "scalar"
     },
     "parameters": [
         {

--- a/src/customfunctions.ts
+++ b/src/customfunctions.ts
@@ -4,10 +4,6 @@ function add(first: number, second: number): number {
   return first + second;
 }
 
-function addAsync(first: number, second: number): Promise<number> {
-  return Promise.resolve(add(first, second));
-}
-
 function increment(incrementBy: number, callback) {
   let result = 0;
   const timer = setInterval(() => {
@@ -20,6 +16,5 @@ function increment(incrementBy: number, callback) {
   };
 }
 
-CustomFunctionMappings.add = add;
-CustomFunctionMappings.addAsync = addAsync;
+CustomFunctionMappings.ADD = add;
 CustomFunctionMappings.INCREMENT = increment;


### PR DESCRIPTION
I added the "id" to the metadata schema, and made the function names uppercase for display. This means that "id" and "name" should be UPPERCASE in the metadata json, as well as the key in CustomFunctionMappings in the code.
I removed the addAsync() function. We should have a better example for an async call.