### PR TITLE
fix: use concurrently to fix build scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,14 +3,15 @@
   "version": "2.0.0",
   "main": "./src/customfunctions.js",
   "scripts": {
-    "start": "start npm run dev-server && start npm run watch && npm run sideload",
-    "start-web": "start npm run dev-server && start npm run watch",
+    "start": "concurrently \"npm run dev-server\" && concurrently \"npm run watch\" && npm run sideload",
+    "start-web": "concurrently \"npm run dev-server\" && concurrently \"npm run watch\"",
     "build": "webpack -p --mode production",
     "dev-server": "webpack-dev-server --mode development --https --key ./certs/server.key --cert ./certs/server.crt --cacert ./certs/ca.crt --port 8081 --hotOnly",
     "sideload": "office-toolbox sideload -m manifest.xml -a excel",
     "watch": "webpack -p --mode development --watch"
   },
   "devDependencies": {
+    "concurrently": "^4.0.1",
     "file-loader": "^1.1.11",
     "html-loader": "^0.5.5",
     "office-addin-node-debugger": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,8 @@
   "version": "2.0.0",
   "main": "./src/customfunctions.js",
   "scripts": {
-    "start": "concurrently \"npm run dev-server\" && concurrently \"npm run watch\" && npm run sideload",
-    "start-web": "concurrently \"npm run dev-server\" && concurrently \"npm run watch\"",
+    "start": "concurrently \"npm run dev-server\" \"npm run watch\" \"npm run sideload\"",
+    "start-web": "concurrently \"npm run dev-server\" \"npm run watch\"",
     "build": "webpack -p --mode production",
     "dev-server": "webpack-dev-server --mode development --https --key ./certs/server.key --cert ./certs/server.crt --cacert ./certs/ca.crt --port 8081 --hotOnly",
     "sideload": "office-toolbox sideload -m manifest.xml -a excel",


### PR DESCRIPTION
The npm scripts `start` and `start-web` were broken. Because they were using a `start` command which was not listed in `devDependencies`. Even when users install `start` as a local dependency. The `npm start` won't work. 

That's because the script name was also `start`. 

Long story short, I migrated from `start` to `concurrently` to get the scripts working again. Which will address #58 