### PR TITLE
add CORS header to dev-server

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,6 +56,9 @@ module.exports = (env, options) => {
       })
     ],
     devServer: {
+      headers: {
+        "Access-Control-Allow-Origin": "*"
+      },
       https: {
         key: fs.readFileSync("./certs/server.key"),
         cert: fs.readFileSync("./certs/server.crt"),


### PR DESCRIPTION
The dev server needs to allow cross-origin requests using the header: `Access-Control-Allow-Origin: *`.