### PR TITLE
remove Requirements Set "CustomFunctionsRuntime" from manifest

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -22,11 +22,6 @@
     <SourceLocation DefaultValue="https://localhost:3000/taskpane.html"/>
   </DefaultSettings>
   <Permissions>ReadWriteDocument</Permissions>
-  <Requirements>
-    <Sets DefaultMinVersion="1.1">
-        <Set Name="CustomFunctionsRuntime" MinVersion="1.1"/>
-    </Sets>
-  </Requirements>  
   <VersionOverrides xmlns="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="VersionOverridesV1_0">
     <Hosts>
       <Host xsi:type="Workbook">


### PR DESCRIPTION
The following requirements will cause manifest validation to fail. I am removing this for now, and we can put it back once manifest validation is updated.

  <Requirements>
    <Sets DefaultMinVersion="1.1">
        <Set Name="CustomFunctionsRuntime" MinVersion="1.1"/>
    </Sets>
  </Requirements>

c:\dev\git\Excel-Custom-Functions>npm run validate

> excel-custom-functions@2.0.0 validate c:\dev\git\Excel-Custom-Functions
> office-toolbox validate -m manifest.xml

Calling validation service. This might take a moment...
-------------------------------------
Validation: Failed

Error #1:
No supported Office products detected: There are no platforms which fulfil the requirements specified in the manifest. The most common reasons for this failure are issues in the Requirements section. Please review the manifest and try again. (link: undefined)
-------------------------------------