### PR TITLE
Add requirements set for CustomFunctions

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -18,6 +18,11 @@
   <Hosts>
     <Host Name="Workbook"/>
   </Hosts>
+  <Requirements>
+      <Sets DefaultMinVersion="1.1">
+          <Set Name="CustomFunctionsRuntime" MinVersion="1.1"/>
+      </Sets>
+  </Requirements>
   <DefaultSettings>
     <SourceLocation DefaultValue="https://localhost:3000/taskpane.html"/>
   </DefaultSettings>


### PR DESCRIPTION
Excel Custom Functions projects should have a requirement set that indicates the add-in should not load. Adding this as the default example (we were waiting for the validation service to have this requirement set and is now updated to accept this change).