### PR TITLE
Fixing breakpoints for VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -33,8 +33,7 @@
       "protocol": "inspector",
       "timeout": 600000,
       "preLaunchTask": "Debug: Excel Desktop",
-      "postDebugTask": "Stop Debug",
-      "outFiles": [ "${workspaceFolder}/dist/**/*.js" ]
+      "postDebugTask": "Stop Debug"
     },
     {
       "name": "Excel Desktop (Edge Chromium)",


### PR DESCRIPTION
Allow breakpoints set in the TypeScript source to bind and break when debugging custom functions.

Fixes https://github.com/OfficeDev/Excel-Custom-Functions/issues/236