### PR TITLE
Making HTML not get auto deleted

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,7 +50,8 @@ module.exports = async (env, options) => {
     },
     plugins: [
       new CleanWebpackPlugin({
-        cleanOnceBeforeBuildPatterns: dev ? [] : ["**/*"]
+        cleanOnceBeforeBuildPatterns: dev ? [] : ["**/*"],
+        cleanAfterEveryBuildPatterns: ["!**/*"]
       }),
       new CustomFunctionsMetadataPlugin({
         output: "functions.json",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -51,7 +51,7 @@ module.exports = async (env, options) => {
     plugins: [
       new CleanWebpackPlugin({
         cleanOnceBeforeBuildPatterns: dev ? [] : ["**/*"],
-        cleanAfterEveryBuildPatterns: ["!**/*"]
+        cleanAfterEveryBuildPatterns: dev ? ["!**/*"] : []
       }),
       new CustomFunctionsMetadataPlugin({
         output: "functions.json",


### PR DESCRIPTION
Had to override the default behavior of the ```CleanWebpackPlugin```. It normally deletes all files creates by other plugins that are not webpack.
This is the case for out HTML, css and one .xml file. So I made it just clean the files before compiling and not after.

Now you can run ```npm run build``` followed by ```npm start``` and the project would work.