### PR TITLE
Making it always wait the same amount

### DIFF
--- a/test/src/test-taskpane.ts
+++ b/test/src/test-taskpane.ts
@@ -26,7 +26,6 @@ async function runCfTests(platform: string): Promise<void> {
             range.formulas = [[formula]];
             await context.sync();
 
-            // Mac is slower so we need to wait longer for the function to return a value
             await sleep(8000);
 
             // Check to if this is a streaming function
@@ -60,7 +59,6 @@ export async function readCFData(cfName: string, readCount: number, platform: st
                     range.load("values");
                     await context.sync();
 
-                    // Mac is slower so we need to wait longer for the function to return a value
                     await sleep(8000);
 
                     addTestResult(cfName, range.values[0][0]);

--- a/test/src/test-taskpane.ts
+++ b/test/src/test-taskpane.ts
@@ -27,7 +27,7 @@ async function runCfTests(platform: string): Promise<void> {
             await context.sync();
 
             // Mac is slower so we need to wait longer for the function to return a value
-            await sleep(platform === "Windows" ? 2000 : 8000);
+            await sleep(8000);
 
             // Check to if this is a streaming function
             await readCFData(key, customFunctionsData[key].streaming != undefined ? 2 : 1, platform)
@@ -61,7 +61,7 @@ export async function readCFData(cfName: string, readCount: number, platform: st
                     await context.sync();
 
                     // Mac is slower so we need to wait longer for the function to return a value
-                    await sleep(platform === "Windows" ? 2000 : 8000);
+                    await sleep(8000);
 
                     addTestResult(cfName, range.values[0][0]);
                     resolve(true);

--- a/test/src/test-taskpane.ts
+++ b/test/src/test-taskpane.ts
@@ -26,7 +26,7 @@ async function runCfTests(platform: string): Promise<void> {
             range.formulas = [[formula]];
             await context.sync();
 
-            await sleep(8000);
+            await sleep(5000);
 
             // Check to if this is a streaming function
             await readCFData(key, customFunctionsData[key].streaming != undefined ? 2 : 1, platform)
@@ -59,7 +59,7 @@ export async function readCFData(cfName: string, readCount: number, platform: st
                     range.load("values");
                     await context.sync();
 
-                    await sleep(8000);
+                    await sleep(5000);
 
                     addTestResult(cfName, range.values[0][0]);
                     resolve(true);


### PR DESCRIPTION
Making test always wait 8000 regardless of flaky tests to make tests more reliable.