### PR TITLE
[BugFix] Duplicate CF name error

### DIFF
--- a/test/test-manifest-debugging.xml
+++ b/test/test-manifest-debugging.xml
@@ -3,7 +3,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:bt="http://schemas.microsoft.com/office/officeappbasictypes/1.0"
   xmlns:ov="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="TaskPaneApp">
-  <Id>a2b37988-b6e8-46df-871e-1cf3cb3d604d</Id>
+  <Id>ca968be6-628b-4f14-ba3c-3e614effa9bd</Id>
   <Version>1.0.0.0</Version>
   <ProviderName>Contoso</ProviderName>
   <DefaultLocale>en-US</DefaultLocale>

--- a/test/test-manifest.xml
+++ b/test/test-manifest.xml
@@ -3,7 +3,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:bt="http://schemas.microsoft.com/office/officeappbasictypes/1.0"
   xmlns:ov="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="TaskPaneApp">
-  <Id>a2b37988-b6e8-46df-871e-1cf3cb3d604d</Id>
+  <Id>ca968be6-628b-4f14-ba3c-3e614effa9bd</Id>
   <Version>1.0.0.0</Version>
   <ProviderName>Contoso</ProviderName>
   <DefaultLocale>en-US</DefaultLocale>


### PR DESCRIPTION
Fixing the error:
"This add-in wasn't installed because a custom function with the same name already exists" when executing `npm start` followed by `npm run test` or the other way around.

This just makes both testings and start have the same manifest ID. I changed the testing manifest IDs to be the same as the start IDs.

Tested by running `npm run start` followed `npm run test` and `npm run test` followed by `npm run start`. Both executed without raising errors and not needing to clear the cache.