### PR TITLE
Making debugger hit and bind

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -51,6 +51,7 @@
       "type": "node",
       "request": "attach",
       "port": 9229,
+      "protocol": "inspector",
       "timeout": 600000,
       "preLaunchTask": "Debug: Excel Desktop",
       "postDebugTask": "Stop Debug",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -54,9 +54,7 @@
       "timeout": 600000,
       "preLaunchTask": "Debug: Excel Desktop",
       "postDebugTask": "Stop Debug",
-      "resolveSourceMapLocations": [
-        "${env:LOCALAPPDATA}/Microsoft/Office/16.0/Wef/**/*.js"
-      ]
+      "resolveSourceMapLocations": null
     },
     {
       "name": "Excel Desktop (Edge Chromium)",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -51,10 +51,12 @@
       "type": "node",
       "request": "attach",
       "port": 9229,
-      "protocol": "inspector",
       "timeout": 600000,
       "preLaunchTask": "Debug: Excel Desktop",
-      "postDebugTask": "Stop Debug"
+      "postDebugTask": "Stop Debug",
+      "resolveSourceMapLocations": [
+        "${env:LOCALAPPDATA}/Microsoft/Office/16.0/Wef/**/*.js"
+      ]
     },
     {
       "name": "Excel Desktop (Edge Chromium)",


### PR DESCRIPTION
Making breakpoints from the source code be hit again.
Fixes the problem where the debugger wouldn't be hit unless debugging directly.

This very probably wouldn't work on Mac, as it requires a direct reference to LocalAppData, which only exists in windows.

Pretty much we needed to directly reference the code that actually runs in the WEF cache.