### PR TITLE
Removing unneeded protocol property

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -51,7 +51,6 @@
       "type": "node",
       "request": "attach",
       "port": 9229,
-      "protocol": "inspector",
       "timeout": 600000,
       "preLaunchTask": "Debug: Excel Desktop",
       "postDebugTask": "Stop Debug"


### PR DESCRIPTION
Removing unneeded property in `launch.json`. VScode complains it is `not allowed` and documentation also says it does not exist when the mode is `attach`.