### PR TITLE
Fixing VSCode Debugger

### DIFF
--- a/test/end-to-end/webpack.config.js
+++ b/test/end-to-end/webpack.config.js
@@ -25,7 +25,6 @@ module.exports = async (env, options) => {
     },
     output: {
       path: path.resolve(__dirname, "testBuild"),
-      devtoolModuleFilenameTemplate: "webpack:///[resource-path]?[loaders]",
       clean: true,
     },
     resolve: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -26,7 +26,6 @@ module.exports = async (env, options) => {
       commands: "./src/commands/commands.ts",
     },
     output: {
-      devtoolModuleFilenameTemplate: "webpack:///[resource-path]?[loaders]",
       clean: true,
     },
     resolve: {


### PR DESCRIPTION
This fix is made to fix this issue of breakpoints not binding for custom functions, making the code not be able to hit breakpoints/