### PR TITLE
Include replacing "public" in function path during webpack build for production

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -91,7 +91,7 @@ module.exports = async (env, options) => {
               if (dev) {
                 return content;
               } else {
-                return content.toString().replace(new RegExp(urlDev, "g"), urlProd);
+                return content.toString().replace(new RegExp(urlDev + "(?:public/)?", "g"), urlProd);
               }
             },
           },


### PR DESCRIPTION
Thank you for your pull request!  Please provide the following information.

---

**Change Description**:
Update the regex in webpack.config.js to replace the "public/" part of the URLs in manifest.xml when doing a production build.

1. **Do these changes impact any *npm scripts* commands (in package.json)?** (e.g., running 'npm run start')
No.

2. **Do these changes impact *VS Code debugging* options (launch.json)?**
No.

3. **Do these changes impact *template output*?** (e.g., add/remove file, update file location, update file contents)
No.

4. **Do these changes impact *documentation*?** (e.g., a tutorial on https://docs.microsoft.com/en-us/office/dev/add-ins/overview/office-add-ins)
Possibly.  If there are any references to the functions file path in the manifest they may need to get corrected.

If you answered yes to any of these please do the following:
    > Include 'Rick-Kirkham' in the review
    > Make sure the README file is correct

**Validation/testing performed**:
Ran the build process for both debug and production for custom functions.